### PR TITLE
Update penny package-lock.json

### DIFF
--- a/penny/package-lock.json
+++ b/penny/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@solid/community-server": "^5.0.0",
-        "penny-pod-inspector": "^0.432398647.1899507564"
+        "penny-pod-inspector": "^0.602110964.279892403"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2241,32 +2241,28 @@
         "@fluent/bundle": ">= 0.13.0"
       }
     },
-    "node_modules/@inrupt/jose-legacy-modules": {
-      "version": "0.0.3-3.15.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/jose-legacy-modules/-/jose-legacy-modules-0.0.3-3.15.4.tgz",
-      "integrity": "sha512-gcmIqLLFyhNZWw9OKK3kNgEbpKU0z6kn6NPWQlJf0Dy5QtuIgwcS7aRU2GJScz+Dx9KGQVvyAapYX3buHyrBXw==",
+    "node_modules/@inrupt/oidc-client": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
+      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
       "dependencies": {
-        "jose": "3.15.4"
-      }
-    },
-    "node_modules/@inrupt/jose-legacy-modules/node_modules/jose": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-3.15.4.tgz",
-      "integrity": "sha512-SXeGi+g5ZcNgV6o7f+Mx3Q1gaYMSBzAi3cmcZPxoeCEZPgfSCnnyfmMXzXoLDh+XL4KMtGvhOsYBoqQhnuR2rQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.2.tgz",
-      "integrity": "sha512-htdqsFnLOSUhi+AkhyYCTA1vjUsZT8TeQOiXEtLDgneCRxwxCGfRwVSgXSC30OeophlgrZ7/QVixaz3BB5yXEA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.2.tgz",
+      "integrity": "sha512-9JZeBfySsU06KSz/sNDSM2FPyE1SGj1VEa4J7s9TngyQ8Bu+Z347E4+ULZesglmXfgtF1IOTaQcBE2XQTOgVPA==",
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client": "^1.11.6",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
-        "oidc-client": "^1.11.3",
+        "jose": "^4.3.7",
         "uuid": "^8.3.1"
       }
     },
@@ -2286,40 +2282,49 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.2.tgz",
-      "integrity": "sha512-DifF7hSMuFEB9+lDAYjRq6E7DOIZjQwdk9gUkPj93tdIb4icHXQ9JTMwBAxXmdTruPC2g5Pzu0PQ0PCvbIpuDA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.12.2.tgz",
+      "integrity": "sha512-7yNKJjg7ObBCtSuus2n8rNIet5FbALzRdrY7JaQlq6frJtRd1IR5KszD+xhC5qdU+HpeUb1s4Q3+HEsPx7KHYA==",
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/oidc-client-ext": "^1.11.2",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client-ext": "^1.12.2",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
         "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^15.0.1",
+        "@types/node": "^18.0.3",
         "@types/uuid": "^8.3.0",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.2.tgz",
-      "integrity": "sha512-hL+BC81lE4V0EXZE8PJ418y/vFvW+rfcmHgHqi0ZKSSxLNVE08Ok4W2d+g6wcW3wyePZ9FOL2K8BIh7/jCGj8Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
+      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/uuid": "^8.3.0",
-        "cross-fetch": "^3.0.6",
+        "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0"
       }
     },
     "node_modules/@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
+      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0"
+      }
     },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
@@ -2341,156 +2346,6 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
       "integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
-      "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
-      "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
-      "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
-      "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
-      "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
-      "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
-      "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
-      "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
-      "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
-      "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "12.1.0",
@@ -2942,6 +2797,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
+      "dependencies": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
+      }
+    },
     "node_modules/@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -2984,9 +2848,9 @@
       "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
     },
     "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -3034,9 +2898,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "version": "18.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
+      "integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ=="
     },
     "node_modules/@types/nodemailer": {
       "version": "6.4.4",
@@ -3612,9 +3476,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.0.tgz",
-      "integrity": "sha512-L1TpFRWXZ76vH1yLM+z6KssLZrP8Z6GxxW4auoCj+XiViOzNPJCAuTIkn03BGdFe6Z5clX5t64wRIRypsZQrUg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -3749,6 +3613,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -4014,11 +3886,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "node_modules/form-urlencoded": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.5.tgz",
-      "integrity": "sha512-7M7IhZNujsHqjYovM1WTSqcAVOqfvgF8acu6ok1ct1a00l6LVrmagJKkOdRUH/PYKEDOZ7ZAw/Mtq1/Q8CuRTQ=="
-    },
     "node_modules/framer-motion": {
       "version": "3.10.6",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-3.10.6.tgz",
@@ -4087,9 +3954,9 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -4415,10 +4282,46 @@
         "node": ">=10"
       }
     },
+    "node_modules/jest-diff": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/jose": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.3.tgz",
+      "integrity": "sha512-3S4wQnaoJKSAx9uHSoyf8B/lxjs1qCntHWL6wNFszJazo+FtWe+qD0zVfY0BlqJ5HHK4jcnM98k3BQzVLbzE4g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4484,11 +4387,6 @@
       "bin": {
         "jsonld-context-parse": "bin/jsonld-context-parse.js"
       }
-    },
-    "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
     },
     "node_modules/jsonld-streaming-parser": {
       "version": "2.4.3",
@@ -4664,7 +4562,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -4927,18 +4825,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
-      "dependencies": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
-      }
-    },
     "node_modules/oidc-provider": {
       "version": "7.10.6",
       "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-7.10.6.tgz",
@@ -5052,15 +4938,15 @@
       }
     },
     "node_modules/penny-pod-inspector": {
-      "version": "0.432398647.1899507564",
-      "resolved": "https://registry.npmjs.org/penny-pod-inspector/-/penny-pod-inspector-0.432398647.1899507564.tgz",
-      "integrity": "sha512-+dmyFyK63nYbV52s4a9bPnlvU7FYS0WPw7iQOaz8GhyJINqhF+6mErhoNUdqwzKRJY8mf+pndOHVjUAzEZ7VuA==",
+      "version": "0.602110964.2798924035",
+      "resolved": "https://registry.npmjs.org/penny-pod-inspector/-/penny-pod-inspector-0.602110964.2798924035.tgz",
+      "integrity": "sha512-+6gmv0O3HnSJtN5LyPspSxfvxDjMuaSh24lRFN4VO2sEEZmQlEhqzKJL3usohZqOv26hQ9bu5WqHz+efRmTpYQ==",
       "dependencies": {
         "@fluent/bundle": "^0.17.0",
         "@fluent/langneg": "^0.6.0",
         "@fluent/react": "^0.14.0",
         "@inrupt/solid-client": "^1.11.0",
-        "@inrupt/solid-client-authn-browser": "^1.8.0",
+        "@inrupt/solid-client-authn-browser": "^1.12.1",
         "@react-aria/focus": "^3.2.4",
         "@react-aria/ssr": "^3.0.1",
         "@react-aria/switch": "^3.1.1",
@@ -5187,6 +5073,35 @@
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/promise-polyfill": {
       "version": "1.1.6",
@@ -8641,31 +8556,28 @@
       "integrity": "sha512-aH1xMwX8DFvKOQSKUKpB3zMsnJ2rRKt7MajLNnx/r3V3DWDo2nzEfm21d7UyOgwEckPIjPmhxdW1MEmsGUxYIw==",
       "requires": {}
     },
-    "@inrupt/jose-legacy-modules": {
-      "version": "0.0.3-3.15.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/jose-legacy-modules/-/jose-legacy-modules-0.0.3-3.15.4.tgz",
-      "integrity": "sha512-gcmIqLLFyhNZWw9OKK3kNgEbpKU0z6kn6NPWQlJf0Dy5QtuIgwcS7aRU2GJScz+Dx9KGQVvyAapYX3buHyrBXw==",
+    "@inrupt/oidc-client": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
+      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
       "requires": {
-        "jose": "3.15.4"
-      },
-      "dependencies": {
-        "jose": {
-          "version": "3.15.4",
-          "resolved": "https://registry.npmjs.org/jose/-/jose-3.15.4.tgz",
-          "integrity": "sha512-SXeGi+g5ZcNgV6o7f+Mx3Q1gaYMSBzAi3cmcZPxoeCEZPgfSCnnyfmMXzXoLDh+XL4KMtGvhOsYBoqQhnuR2rQ=="
-        }
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.2.tgz",
-      "integrity": "sha512-htdqsFnLOSUhi+AkhyYCTA1vjUsZT8TeQOiXEtLDgneCRxwxCGfRwVSgXSC30OeophlgrZ7/QVixaz3BB5yXEA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.2.tgz",
+      "integrity": "sha512-9JZeBfySsU06KSz/sNDSM2FPyE1SGj1VEa4J7s9TngyQ8Bu+Z347E4+ULZesglmXfgtF1IOTaQcBE2XQTOgVPA==",
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client": "^1.11.6",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
-        "oidc-client": "^1.11.3",
+        "jose": "^4.3.7",
         "uuid": "^8.3.1"
       }
     },
@@ -8685,40 +8597,43 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.2.tgz",
-      "integrity": "sha512-DifF7hSMuFEB9+lDAYjRq6E7DOIZjQwdk9gUkPj93tdIb4icHXQ9JTMwBAxXmdTruPC2g5Pzu0PQ0PCvbIpuDA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.12.2.tgz",
+      "integrity": "sha512-7yNKJjg7ObBCtSuus2n8rNIet5FbALzRdrY7JaQlq6frJtRd1IR5KszD+xhC5qdU+HpeUb1s4Q3+HEsPx7KHYA==",
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/oidc-client-ext": "^1.11.2",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client-ext": "^1.12.2",
+        "@inrupt/solid-client-authn-core": "^1.12.2",
         "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^15.0.1",
+        "@types/node": "^18.0.3",
         "@types/uuid": "^8.3.0",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.2.tgz",
-      "integrity": "sha512-hL+BC81lE4V0EXZE8PJ418y/vFvW+rfcmHgHqi0ZKSSxLNVE08Ok4W2d+g6wcW3wyePZ9FOL2K8BIh7/jCGj8Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
+      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/uuid": "^8.3.0",
-        "cross-fetch": "^3.0.6",
+        "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
       }
     },
     "@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
+      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
+      "requires": {
+        "@rdfjs/types": "^1.1.0"
+      }
     },
     "@ioredis/commands": {
       "version": "1.2.0",
@@ -8737,66 +8652,6 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
       "integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
-    },
-    "@next/swc-android-arm64": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
-      "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
-      "optional": true
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
-      "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
-      "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
-      "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
-      "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
-      "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
-      "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
-      "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
-      "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
-      "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
-      "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "12.1.0",
@@ -9185,6 +9040,15 @@
         "@types/node": "*"
       }
     },
+    "@types/jest": {
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
+      "requires": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
+      }
+    },
     "@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -9227,9 +9091,9 @@
       "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
     },
     "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -9277,9 +9141,9 @@
       }
     },
     "@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "version": "18.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
+      "integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ=="
     },
     "@types/nodemailer": {
       "version": "6.4.4",
@@ -9751,9 +9615,9 @@
       }
     },
     "core-js": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.0.tgz",
-      "integrity": "sha512-L1TpFRWXZ76vH1yLM+z6KssLZrP8Z6GxxW4auoCj+XiViOzNPJCAuTIkn03BGdFe6Z5clX5t64wRIRypsZQrUg=="
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+      "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
     },
     "cors": {
       "version": "2.8.5",
@@ -9844,6 +9708,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.1.1.tgz",
       "integrity": "sha512-jxwFW+yrVOLdwqIWvowFOM8UPdhZnvOF6mhXQQLXMxBDLtv2JVJlVJPEwkDv9prqscEtGtmnxuuI6pQKStK1vA=="
+    },
+    "diff-sequences": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ=="
     },
     "dom-serializer": {
       "version": "1.4.1",
@@ -10043,11 +9912,6 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "form-urlencoded": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.5.tgz",
-      "integrity": "sha512-7M7IhZNujsHqjYovM1WTSqcAVOqfvgF8acu6ok1ct1a00l6LVrmagJKkOdRUH/PYKEDOZ7ZAw/Mtq1/Q8CuRTQ=="
-    },
     "framer-motion": {
       "version": "3.10.6",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-3.10.6.tgz",
@@ -10095,9 +9959,9 @@
       }
     },
     "got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -10322,10 +10186,37 @@
         "minimatch": "^3.0.4"
       }
     },
+    "jest-diff": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      }
+    },
+    "jest-get-type": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw=="
+    },
+    "jest-matcher-utils": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      }
+    },
     "jose": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.3.tgz",
-      "integrity": "sha512-7rySkpW78d8LBp4YU70Wb7+OTgE3OwAALNVZxhoIhp4Kscp+p/fBkdpxGAMKxvCAMV4QfXBU9m6l9nX/vGwd2g=="
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.3.tgz",
+      "integrity": "sha512-3S4wQnaoJKSAx9uHSoyf8B/lxjs1qCntHWL6wNFszJazo+FtWe+qD0zVfY0BlqJ5HHK4jcnM98k3BQzVLbzE4g=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -10373,13 +10264,6 @@
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.6.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-          "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
-        }
       }
     },
     "jsonld-streaming-parser": {
@@ -10512,7 +10396,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -10699,18 +10583,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
-    "oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
-      "requires": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
-      }
-    },
     "oidc-provider": {
       "version": "7.10.6",
       "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-7.10.6.tgz",
@@ -10790,15 +10662,15 @@
       "optional": true
     },
     "penny-pod-inspector": {
-      "version": "0.432398647.1899507564",
-      "resolved": "https://registry.npmjs.org/penny-pod-inspector/-/penny-pod-inspector-0.432398647.1899507564.tgz",
-      "integrity": "sha512-+dmyFyK63nYbV52s4a9bPnlvU7FYS0WPw7iQOaz8GhyJINqhF+6mErhoNUdqwzKRJY8mf+pndOHVjUAzEZ7VuA==",
+      "version": "0.602110964.2798924035",
+      "resolved": "https://registry.npmjs.org/penny-pod-inspector/-/penny-pod-inspector-0.602110964.2798924035.tgz",
+      "integrity": "sha512-+6gmv0O3HnSJtN5LyPspSxfvxDjMuaSh24lRFN4VO2sEEZmQlEhqzKJL3usohZqOv26hQ9bu5WqHz+efRmTpYQ==",
       "requires": {
         "@fluent/bundle": "^0.17.0",
         "@fluent/langneg": "^0.6.0",
         "@fluent/react": "^0.14.0",
         "@inrupt/solid-client": "^1.11.0",
-        "@inrupt/solid-client-authn-browser": "^1.8.0",
+        "@inrupt/solid-client-authn-browser": "^1.12.1",
         "@react-aria/focus": "^3.2.4",
         "@react-aria/ssr": "^3.0.1",
         "@react-aria/switch": "^3.1.1",
@@ -10887,6 +10759,28 @@
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.1"
+      }
+    },
+    "pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "promise-polyfill": {


### PR DESCRIPTION
After cloning the repo and following README instructions for using penny, I get a bunch of errors:
```
MINGW64 ~/GitHub/Recipes/penny $ npm ci --only production
npm WARN config only Use `--omit=dev` to omit dev dependencies from the install.
npm ERR! code EUSAGE
npm ERR!
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR!
npm ERR! Invalid: lock file's penny-pod-inspector@0.432398647.1899507564 does not satisfy penny-pod-inspector@0.602110964.2798924035
npm ERR! Invalid: lock file's @inrupt/solid-client-authn-browser@1.11.2 does not satisfy @inrupt/solid-client-authn-browser@1.12.2
npm ERR! Invalid: lock file's @inrupt/oidc-client-ext@1.11.2 does not satisfy @inrupt/oidc-client-ext@1.12.2
npm ERR! Invalid: lock file's @inrupt/solid-client-authn-core@1.11.2 does not satisfy @inrupt/solid-client-authn-core@1.12.2
npm ERR! Invalid: lock file's @types/lodash.clonedeep@4.5.6 does not satisfy @types/lodash.clonedeep@4.5.7
npm ERR! Invalid: lock file's @types/node@15.14.9 does not satisfy @types/node@18.11.5
npm ERR! Missing: @inrupt/oidc-client@1.11.6 from lock file
npm ERR! Missing: @types/jest@27.5.2 from lock file
npm ERR! Invalid: lock file's core-js@3.19.0 does not satisfy core-js@3.26.0
npm ERR! Invalid: lock file's @inrupt/solid-common-vocab@1.0.0 does not satisfy @inrupt/solid-common-vocab@1.0.1
npm ERR! Missing: jest-matcher-utils@27.5.1 from lock file
npm ERR! Missing: pretty-format@27.5.1 from lock file
npm ERR! Missing: jest-diff@27.5.1 from lock file
npm ERR! Missing: jest-get-type@27.5.1 from lock file
npm ERR! Missing: diff-sequences@27.5.1 from lock file
npm ERR! Missing: ansi-styles@5.2.0 from lock file
npm ERR! Missing: react-is@17.0.2 from lock file
```

I think this is because only `package.json` but not `package-lock.json` was updated in https://github.com/CommunitySolidServer/Recipes/pull/22
This updates the `package-lock.json` with the result after running `npm install` and `npm audit fix`.