### PR TITLE
Add Dockerfiles and Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ You can launch the Community Solid Server with the following user interfaces:
 - [Penny](https://forum.solidproject.org/t/new-developer-tool-app-penny/3837)
 
 
-## ⚙️ Installing the recipes
+## ⚙️ Installing the recipes using Node
+
 ```shell
 # Load the configurations to your device
 git clone https://github.com/CommunitySolidServer/Recipes
@@ -22,7 +23,7 @@ npm ci --production
 ```
 
 
-## 🚀 Starting the server from a recipe
+## 🚀 Starting the server from a recipe using Node
 
 ### Mashlib
 The Mashlib configurations are in the `mashlib` folder.
@@ -41,4 +42,18 @@ The Penny configurations are in the `penny` folder.
 ```shell
 # Start the server with your documents folder as the root container
 npx community-solid-server -c config-penny.json -f ~/Documents/
+```
+
+
+## 🐋 Installing/running using Docker
+
+With Docker, you can combine the steps of installing the recipes and starting the server into one.
+
+```shell
+git clone https://github.com/CommunitySolidServer/Recipes
+cd Recipes/
+docker build -f mashlib/Dockerfile -t css-recipes:mashlib .
+# docker build -f penny/Dockerfile -t css-recipes:penny .
+docker run --rm -v ~/Documents/:/data/ -p 3000:3000 -it css-recipes:mashlib -c config/config-mashlib.json
+# docker run --rm -v ~/Documents/:/data/ -p 3000:300 -it css-recipes:penny -c config/config-penny.json
 ```

--- a/mashlib/Dockerfile
+++ b/mashlib/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:lts-alpine AS build
+WORKDIR /usr/src/app/
+COPY /mashlib/ ./
+RUN npm clean-install --omit=dev
+
+FROM solidproject/community-server AS production
+COPY --from=build /usr/src/app/node_modules/ /community-server/node_modules/
+COPY /mashlib/config* /community-server/config/

--- a/penny/Dockerfile
+++ b/penny/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:lts-alpine AS build
+WORKDIR /usr/src/app/
+COPY /penny/ ./
+RUN npm clean-install --omit=dev
+
+FROM solidproject/community-server AS production
+COPY --from=build /usr/src/app/node_modules/ /community-server/node_modules/
+COPY /penny/config* /community-server/config/


### PR DESCRIPTION
The main https://github.com/CommunitySolidServer/CommunitySolidServer repo has instructions for running with Docker. To make integrating the recipes easier into existing Docker workflows, I've added a minimal Dockerfile for each of the extensions and instructions how to use them.

I've only recently started using Docker, so a review of the Dockerfiles by someone with more experience might be helpful