### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ cd community-server-recipes
 
 # Pick the configuration of your choice, and install its dependencies
 cd mashlib   # or penny
-npm ci --production
+npm ci --omit=dev
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ cd community-server-recipes
 # Pick the configuration of your choice, and install its dependencies
 cd mashlib   # or penny
 npm ci --omit=dev
-
 ```
 
 


### PR DESCRIPTION
```
penny$ npm ci --production
npm WARN config production Use `--omit=dev` instead.
npm WARN deprecated @types/lru-cache@7.10.10: This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.

added 739 packages, and audited 740 packages in 20s

41 packages are looking for funding
  run `npm fund` for details

1 high severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.```