### PR TITLE
update dependencies for mashlib and penny recipes to actual version

### DIFF
--- a/mashlib/package-lock.json
+++ b/mashlib/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@solid/community-server": "^7.0.2",
-        "mashlib": "^1.8.8"
+        "@solid/community-server": "^7.0.3",
+        "mashlib": "^1.8.9"
       }
     },
     "node_modules/@babel/runtime": {

--- a/mashlib/package.json
+++ b/mashlib/package.json
@@ -4,7 +4,7 @@
     "start:dev": "npx community-solid-server -c config-mashlib-dev.json"
   },
   "dependencies": {
-    "@solid/community-server": "^7.0.2",
-    "mashlib": "^1.8.8"
+    "@solid/community-server": "^7.0.3",
+    "mashlib": "^1.8.9"
   }
 }

--- a/penny/package-lock.json
+++ b/penny/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@solid/community-server": "^7.0.2",
+        "@solid/community-server": "^7.0.3",
         "penny-pod-inspector": "^0.1024692321.5216227821"
       }
     },

--- a/penny/package.json
+++ b/penny/package.json
@@ -3,7 +3,7 @@
     "start": "npx community-solid-server -c config-penny.json"
   },
   "dependencies": {
-    "@solid/community-server": "^7.0.2",
+    "@solid/community-server": "^7.0.3",
     "penny-pod-inspector": "^0.1024692321.5216227821"
   }
 }


### PR DESCRIPTION
@joachimvh 

I took the freedom to update the config.
did I do this right ?
I am not sure though, if the `penny-pod-inspector" version link also changed...

I hope this is no damage and a useful contribution, otherwise correct me.....