### PR TITLE
update mashlib and penny recipes to CSS 7.0.4 respective mashlib 1.8.10-1 as on npmjs

### DIFF
--- a/mashlib/package-lock.json
+++ b/mashlib/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@solid/community-server": "^7.0.4",
-        "mashlib": "^1.8.10-1"
+        "mashlib": "^1.8.9"
       }
     },
     "node_modules/@babel/runtime": {

--- a/mashlib/package-lock.json
+++ b/mashlib/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@solid/community-server": "^7.0.3",
-        "mashlib": "^1.8.9"
+        "@solid/community-server": "^7.0.4",
+        "mashlib": "^1.8.10-1"
       }
     },
     "node_modules/@babel/runtime": {

--- a/mashlib/package.json
+++ b/mashlib/package.json
@@ -5,6 +5,6 @@
   },
   "dependencies": {
     "@solid/community-server": "^7.0.4",
-    "mashlib": "^1.8.10-1"
+    "mashlib": "^1.8.9"
   }
 }

--- a/mashlib/package.json
+++ b/mashlib/package.json
@@ -4,7 +4,7 @@
     "start:dev": "npx community-solid-server -c config-mashlib-dev.json"
   },
   "dependencies": {
-    "@solid/community-server": "^7.0.3",
-    "mashlib": "^1.8.9"
+    "@solid/community-server": "^7.0.4",
+    "mashlib": "^1.8.10-1"
   }
 }

--- a/penny/package-lock.json
+++ b/penny/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@solid/community-server": "^7.0.3",
+        "@solid/community-server": "^7.0.4",
         "penny-pod-inspector": "^0.1024692321.5216227821"
       }
     },

--- a/penny/package.json
+++ b/penny/package.json
@@ -3,7 +3,7 @@
     "start": "npx community-solid-server -c config-penny.json"
   },
   "dependencies": {
-    "@solid/community-server": "^7.0.3",
+    "@solid/community-server": "^7.0.4",
     "penny-pod-inspector": "^0.1024692321.5216227821"
   }
 }


### PR DESCRIPTION
@joachimvh 

I have done the same procedure as on 7.0.3 change.

I have used the versions that are published on the official npmjs.com site/repo

do you think these changes are done correct and reflecting the actual dependencies ?