### PR TITLE
update necessary dependencies (7.1.1)

### DIFF
--- a/mashlib/package-lock.json
+++ b/mashlib/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@solid/community-server": "^7.1.0",
+        "@solid/community-server": "^7.1.1",
         "mashlib": "^1.8.11"
       }
     },

--- a/mashlib/package.json
+++ b/mashlib/package.json
@@ -4,7 +4,7 @@
     "start:dev": "npx community-solid-server -c config-mashlib-dev.json"
   },
   "dependencies": {
-    "@solid/community-server": "^7.1.0",
+    "@solid/community-server": "^7.1.1",
     "mashlib": "^1.8.11"
   }
 }

--- a/penny/package-lock.json
+++ b/penny/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@solid/community-server": "^7.1.0",
+        "@solid/community-server": "^7.1.1",
         "penny-pod-inspector": "^0.1287542150.6831902715"
       }
     },

--- a/penny/package.json
+++ b/penny/package.json
@@ -3,7 +3,7 @@
     "start": "npx community-solid-server -c config-penny.json"
   },
   "dependencies": {
-    "@solid/community-server": "^7.1.0",
+    "@solid/community-server": "^7.1.1",
     "penny-pod-inspector": "^0.1287542150.6831902715"
   }
 }


### PR DESCRIPTION
d2024-08-18 t04:05

@joachimvh 

I have updated the necessary dependencies.
that seemed to be only for CSS.

mashlib and penny didn't seemed to change, as in
https://www.npmjs.com/package/mashlib and
https://www.npmjs.com/package/penny-pod-inspector