### PR TITLE
chore(docs): fix start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The Mashlib configurations are in the `mashlib` folder.
 
 ```shell
 # Start the server with your documents folder as the root container
-npx community-solid-server -c config-mashlib.json -f ~/Documents/
+npx @solid/community-server -c config-mashlib.json -f ~/Documents/
 
 # Start the server in development mode (authenticated as a specific user)
-npx community-solid-server -c config-mashlib-dev.json -f ~/Documents/
+npx @solid/community-server -c config-mashlib-dev.json -f ~/Documents/
 ```
 
 ### Penny
@@ -40,7 +40,7 @@ The Penny configurations are in the `penny` folder.
 
 ```shell
 # Start the server with your documents folder as the root container
-npx community-solid-server -c config-penny.json -f ~/Documents/
+npx @solid/community-server -c config-penny.json -f ~/Documents/
 ```
 
 ## 📜 Customizing the recipes


### PR DESCRIPTION
When using `npx` you need to use the package name, rather than the name the package declares in the `bin` field.